### PR TITLE
Display searched word

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,32 +1,32 @@
 <template>
   <div id="app">
     <Header />
-    <SearchSynonyms v-on:display-synonym="displaySynonym" />
-    <SynonymsContainer v-bind:synonyms="synonyms" />
+    <SearchWord v-on:display-word="displayWord" />
+    <WordsContainer v-bind:words="words" />
   </div>
 </template>
 
 <script>
 import { getSearchedSynonym } from "./util/apiCalls";
 import Header from "./components/Header";
-import SearchSynonyms from "./components/SearchSynonyms";
-import SynonymsContainer from "./components/SynonymsContainer";
+import SearchWord from "./components/SearchWord";
+import WordsContainer from "./components/WordsContainer";
 
 export default {
   name: "app",
   components: {
     Header,
-    SearchSynonyms,
-    SynonymsContainer
+    SearchWord,
+    WordsContainer
   },
   data() {
     return {
-      synonyms: []
+      words: []
     };
   },
   methods: {
-    displaySynonym(synonym) {
-      getSearchedSynonym(synonym).then(data => (this.synonyms = data));
+    displayWord(word) {
+      getSearchedSynonym(word).then(data => (this.words = data));
     }
   }
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
   <div id="app">
     <Header />
     <SearchSynonyms v-on:display-synonym="displaySynonym" />
+    <SynonymsContainer />
   </div>
 </template>
 
@@ -9,12 +10,14 @@
 import { getSearchedSynonym } from "./util/apiCalls";
 import Header from "./components/Header";
 import SearchSynonyms from "./components/SearchSynonyms";
+import SynonymsContainer from "./components/SynonymsContainer";
 
 export default {
   name: "app",
   components: {
     Header,
-    SearchSynonyms
+    SearchSynonyms,
+    SynonymsContainer
   },
   data() {
     return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <Header />
     <SearchSynonyms v-on:display-synonym="displaySynonym" />
-    <SynonymsContainer />
+    <SynonymsContainer v-bind:synonyms="synonyms" />
   </div>
 </template>
 

--- a/src/components/SearchWord.vue
+++ b/src/components/SearchWord.vue
@@ -1,24 +1,24 @@
 <template>
   <form @submit="search">
-    <input type="text" name="synonym" placeholder="Search synonym" v-model="synonym" />
+    <input type="text" name="word" placeholder="Search word" v-model="word" />
     <button>Submit</button>
   </form>
 </template>
 
 <script>
 export default {
-  name: "SearchSynonyms",
+  name: "SearchWord",
   data() {
     return {
-      synonym: ""
+      word: ""
     };
   },
   methods: {
     search(e) {
       e.preventDefault();
 
-      this.$emit("display-synonym", this.synonym);
-      this.synonym = "";
+      this.$emit("display-word", this.word);
+      this.word = "";
     }
   }
 };

--- a/src/components/SynonymsContainer.vue
+++ b/src/components/SynonymsContainer.vue
@@ -1,10 +1,18 @@
 <template>
-  <section></section>
+  <section>
+    <div v-bind:key="word.id" v-for="word in synonyms">
+      <Word v-bind:word="word" />
+    </div>
+  </section>
 </template>
 
 <script>
+import Word from "./Word";
 export default {
   name: "SynonymsContainer",
+  components: {
+    Word
+  },
   props: ["synonyms"]
 };
 </script>

--- a/src/components/SynonymsContainer.vue
+++ b/src/components/SynonymsContainer.vue
@@ -1,0 +1,12 @@
+<template>
+  <section></section>
+</template>
+
+<script>
+export default {
+  name: "SynonymsContainer"
+};
+</script>
+
+<style scoped>
+</style>

--- a/src/components/SynonymsContainer.vue
+++ b/src/components/SynonymsContainer.vue
@@ -4,7 +4,8 @@
 
 <script>
 export default {
-  name: "SynonymsContainer"
+  name: "SynonymsContainer",
+  props: ["synonyms"]
 };
 </script>
 

--- a/src/components/Word.vue
+++ b/src/components/Word.vue
@@ -5,6 +5,9 @@
     <ul v-bind:key="def" v-for="def in word.shortdef">
       <li>{{def}}</li>
     </ul>
+    <div v-bind:key="synonym" v-for="synonym in word.meta.syns.flat()">
+      <button>{{synonym}}</button>
+    </div>
   </article>
 </template>
 

--- a/src/components/Word.vue
+++ b/src/components/Word.vue
@@ -1,6 +1,10 @@
 <template>
-  <article>
-    <p>Card</p>
+  <article class="word">
+    <p>{{word.meta.id}}</p>
+    <p>{{word.fl}}</p>
+    <ul v-bind:key="def" v-for="def in word.shortdef">
+      <li>{{def}}</li>
+    </ul>
   </article>
 </template>
 
@@ -12,5 +16,9 @@ export default {
 </script>
 
 <style scoped>
+.word {
+  padding: 20px;
+  text-align: center;
+}
 </style>
 

--- a/src/components/Word.vue
+++ b/src/components/Word.vue
@@ -1,0 +1,16 @@
+<template>
+  <article>
+    <p>Card</p>
+  </article>
+</template>
+
+<script>
+export default {
+  name: "Word",
+  props: ["word"]
+};
+</script>
+
+<style scoped>
+</style>
+

--- a/src/components/WordsContainer.vue
+++ b/src/components/WordsContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <div v-bind:key="word.id" v-for="word in synonyms">
+    <div v-bind:key="word.id" v-for="word in words">
       <Word v-bind:word="word" />
     </div>
   </section>
@@ -9,11 +9,11 @@
 <script>
 import Word from "./Word";
 export default {
-  name: "SynonymsContainer",
+  name: "WordsContainer",
   components: {
     Word
   },
-  props: ["synonyms"]
+  props: ["words"]
 };
 </script>
 


### PR DESCRIPTION
#### What does this PR do?
- Verbiage was unclear, so changed the use of synonym to words/word to better clarify the use of each component
- After a user searches for a word, the word displays with part of speech, definitions, and all of the synonyms for that word.

#### Where should the reviewer start?
App.vue (see changed naming conventions)

#### Any background context you want to provide?
I noticed the use of synonyms were confusing, so I wanted to update it now before proceeding forward with the current naming conventions.

#### What are the relevant tickets?
Once a user searches a synonym it displays below #6
