### PR TITLE
Display clicked synonym

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,25 @@ export default {
   },
   methods: {
     displayWord(word) {
-      getSearchedSynonym(word).then(data => (this.words = data));
+      getSearchedSynonym(word)
+        .then(data => this.cleanData(data))
+        .then(data => (this.words = data));
+    },
+    cleanData(data) {
+      return data.map(el => {
+        return {
+          name: el.meta.id,
+          type: el.fl,
+          definition: el.shortdef,
+          syns: el.meta.syns
+            .flat()
+            .reduce(
+              (unique, synonym) =>
+                unique.includes(synonym) ? unique : [...unique, synonym],
+              []
+            )
+        };
+      });
     }
   }
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <Header />
     <SearchWord v-on:display-word="displayWord" />
-    <WordsContainer v-bind:words="words" />
+    <WordsContainer v-bind:words="words" v-on:display-word="displayWord" />
   </div>
 </template>
 

--- a/src/components/Word.vue
+++ b/src/components/Word.vue
@@ -6,7 +6,7 @@
       <li>{{def}}</li>
     </ul>
     <div v-bind:key="synonym" v-for="synonym in word.meta.syns.flat()">
-      <button>{{synonym}}</button>
+      <button @click="$emit('display-word', synonym)">{{synonym}}</button>
     </div>
   </article>
 </template>
@@ -19,9 +19,5 @@ export default {
 </script>
 
 <style scoped>
-.word {
-  padding: 20px;
-  text-align: center;
-}
 </style>
 

--- a/src/components/Word.vue
+++ b/src/components/Word.vue
@@ -5,7 +5,7 @@
     <ul v-bind:key="def" v-for="def in word.shortdef">
       <li>{{def}}</li>
     </ul>
-    <div v-bind:key="synonym" v-for="synonym in word.meta.syns.flat()">
+    <div v-bind:key="synonym" v-for="synonym in word.meta.syns">
       <button @click="$emit('display-word', synonym)">{{synonym}}</button>
     </div>
   </article>

--- a/src/components/WordsContainer.vue
+++ b/src/components/WordsContainer.vue
@@ -1,12 +1,12 @@
 <template>
   <section>
-    <article class="word" v-bind:key="word.id" v-for="word in words">
-      <p>{{word.meta.id}}</p>
-      <p>{{word.fl}}</p>
-      <ul v-bind:key="def" v-for="def in word.shortdef">
+    <article class="word" v-bind:key="`${word.name}${word.type}`" v-for="word in words">
+      <p>{{word.name}}</p>
+      <p>{{word.type}}</p>
+      <ul v-bind:key="def" v-for="def in word.definition">
         <li>{{def}}</li>
       </ul>
-      <div v-bind:key="synonym" v-for="synonym in word.meta.syns.flat()">
+      <div v-bind:key="synonym" v-for="synonym in word.syns">
         <button @click="$emit('display-word', synonym)">{{synonym}}</button>
       </div>
     </article>

--- a/src/components/WordsContainer.vue
+++ b/src/components/WordsContainer.vue
@@ -1,21 +1,28 @@
 <template>
   <section>
-    <div v-bind:key="word.id" v-for="word in words">
-      <Word v-bind:word="word" />
-    </div>
+    <article class="word" v-bind:key="word.id" v-for="word in words">
+      <p>{{word.meta.id}}</p>
+      <p>{{word.fl}}</p>
+      <ul v-bind:key="def" v-for="def in word.shortdef">
+        <li>{{def}}</li>
+      </ul>
+      <div v-bind:key="synonym" v-for="synonym in word.meta.syns.flat()">
+        <button @click="$emit('display-word', synonym)">{{synonym}}</button>
+      </div>
+    </article>
   </section>
 </template>
 
 <script>
-import Word from "./Word";
 export default {
   name: "WordsContainer",
-  components: {
-    Word
-  },
   props: ["words"]
 };
 </script>
 
 <style scoped>
+.word {
+  padding: 20px;
+  text-align: center;
+}
 </style>


### PR DESCRIPTION
#### What does this PR do?
When a user clicks on a specific synonym, the displayed word changes to the word that was clicked on. 

#### Where should the reviewer start?
WordsContainer.vue

#### Any background context you want to provide?
I moved around the main component, because the actions being passed with $emit were undefined in the WordsContainer. In addition, the application was breaking because there were repeated synonyms in the original list. Thus I created a helper method for cleaning out this data, so all synonyms are unique.

#### What are the relevant tickets?
On click of a synonym, that synonym is displayed on the page #8
